### PR TITLE
Enforce devtools::document() before every push

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,9 +4,12 @@
 ^data-raw$
 ^README\.Rmd$
 ^\.github$
+^\.githooks$
+^\.gitattributes$
 ^\.claude$
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^CONTRIBUTING\.md$
 ^CRAN-SUBMISSION$
 ^cran-comments\.md$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Keep shell scripts (e.g. git hooks) with LF endings on all platforms;
+# bash refuses to interpret scripts with CRLF.
+.githooks/* text eol=lf
+*.sh        text eol=lf

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -21,11 +21,18 @@ if ! Rscript -e 'requireNamespace("devtools", quietly = TRUE) || quit(status = 1
   exit 0
 fi
 
-# On Windows, Git Bash sets LC_ALL=C.UTF-8 which native R does not
-# recognise; it then falls back to the "C" locale and mangles non-ASCII
-# author names when re-reading DESCRIPTION. Drop those vars so Rscript
-# inherits the OS-native UTF-8 locale (no-op on Linux/macOS).
-unset LC_ALL LC_CTYPE LANG
+# On Windows, Git Bash may set locale vars to C.UTF-8, which native R does
+# not recognise; it then falls back to the "C" locale and mangles non-ASCII
+# author names when re-reading DESCRIPTION. Only drop those vars when
+# running under Git Bash on Windows and they are set to that problematic
+# value, so valid UTF-8 locales on Linux/macOS are preserved.
+case "$(uname -s)" in
+  MSYS*|MINGW*)
+    [ "${LC_ALL-}" = "C.UTF-8" ] && unset LC_ALL
+    [ "${LC_CTYPE-}" = "C.UTF-8" ] && unset LC_CTYPE
+    [ "${LANG-}" = "C.UTF-8" ] && unset LANG
+    ;;
+esac
 
 echo "[pre-push] Running devtools::document() ..."
 Rscript -e 'suppressMessages(devtools::document(quiet = TRUE))'

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Pre-push hook: ensures roxygen documentation in man/ and NAMESPACE is
+# regenerated before every push, so PRs never carry stale Rd files.
+#
+# Activate once per clone with:
+#   git config core.hooksPath .githooks
+#
+# To bypass for a single push (e.g., emergency hotfix):
+#   git push --no-verify
+
+set -e
+
+if ! command -v Rscript >/dev/null 2>&1; then
+  echo "[pre-push] Rscript not found in PATH — skipping doc check." >&2
+  exit 0
+fi
+
+if ! Rscript -e 'requireNamespace("devtools", quietly = TRUE) || quit(status = 1)' >/dev/null 2>&1; then
+  echo "[pre-push] devtools package not installed — skipping doc check." >&2
+  echo "[pre-push] Install it with: install.packages('devtools')" >&2
+  exit 0
+fi
+
+# On Windows, Git Bash sets LC_ALL=C.UTF-8 which native R does not
+# recognise; it then falls back to the "C" locale and mangles non-ASCII
+# author names when re-reading DESCRIPTION. Drop those vars so Rscript
+# inherits the OS-native UTF-8 locale (no-op on Linux/macOS).
+unset LC_ALL LC_CTYPE LANG
+
+echo "[pre-push] Running devtools::document() ..."
+Rscript -e 'suppressMessages(devtools::document(quiet = TRUE))'
+
+# If document() changed anything tracked by git, abort the push and tell
+# the user to commit the regenerated files.
+TRACKED_CHANGED="$(git diff --name-only -- man/ NAMESPACE DESCRIPTION)"
+if [ -n "$TRACKED_CHANGED" ]; then
+  echo "" >&2
+  echo "[pre-push] ERROR: documentation is out of date." >&2
+  echo "[pre-push] devtools::document() regenerated the following files:" >&2
+  echo "$TRACKED_CHANGED" | sed 's/^/  - /' >&2
+  echo "" >&2
+  echo "[pre-push] Stage and commit the changes, then push again:" >&2
+  echo "  git add man/ NAMESPACE DESCRIPTION" >&2
+  echo "  git commit -m 'Regenerate docs'" >&2
+  echo "  git push" >&2
+  exit 1
+fi
+
+echo "[pre-push] Documentation is up to date."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,14 +30,15 @@ unset LC_ALL LC_CTYPE LANG
 echo "[pre-push] Running devtools::document() ..."
 Rscript -e 'suppressMessages(devtools::document(quiet = TRUE))'
 
-# If document() changed anything tracked by git, abort the push and tell
+# If document() left any unstaged, staged-but-uncommitted, or untracked
+# changes in the generated documentation paths, abort the push and tell
 # the user to commit the regenerated files.
-TRACKED_CHANGED="$(git diff --name-only -- man/ NAMESPACE DESCRIPTION)"
-if [ -n "$TRACKED_CHANGED" ]; then
+DOC_STATUS="$(git status --porcelain -- man/ NAMESPACE DESCRIPTION)"
+if [ -n "$DOC_STATUS" ]; then
   echo "" >&2
   echo "[pre-push] ERROR: documentation is out of date." >&2
-  echo "[pre-push] devtools::document() regenerated the following files:" >&2
-  echo "$TRACKED_CHANGED" | sed 's/^/  - /' >&2
+  echo "[pre-push] devtools::document() regenerated or affected the following files:" >&2
+  echo "$DOC_STATUS" | sed 's/^.. /  - /' >&2
   echo "" >&2
   echo "[pre-push] Stage and commit the changes, then push again:" >&2
   echo "  git add man/ NAMESPACE DESCRIPTION" >&2

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::roxygen2, any::devtools, local::.
+          extra-packages: any::roxygen2, any::remotes, local::.
           needs: roxygen2
 
       - name: Pin roxygen2 to the version recorded in DESCRIPTION

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,0 +1,60 @@
+# Enforces that roxygen-generated man/ and NAMESPACE files are checked in
+# and in sync with their R/ sources. Catches PRs that updated the source
+# but forgot to run devtools::document(), preventing silent drift between
+# the code and the published documentation.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: document.yaml
+
+permissions: read-all
+
+jobs:
+  document:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::roxygen2, any::devtools, local::.
+          needs: roxygen2
+
+      - name: Pin roxygen2 to the version recorded in DESCRIPTION
+        run: |
+          ver <- read.dcf("DESCRIPTION")[, "Config/roxygen2/version"]
+          current <- as.character(utils::packageVersion("roxygen2"))
+          if (!is.na(ver) && length(ver) == 1 && nzchar(ver) && current != ver) {
+            cat("Installing roxygen2 ", ver, " (currently ", current, ")\n", sep = "")
+            remotes::install_version("roxygen2", version = ver, repos = "https://cloud.r-project.org")
+          }
+        shell: Rscript {0}
+
+      - name: Regenerate documentation
+        run: roxygen2::roxygenise()
+        shell: Rscript {0}
+
+      - name: Verify man/ NAMESPACE DESCRIPTION are committed and in sync
+        shell: bash
+        run: |
+          if [[ -n "$(git status --porcelain -- man/ NAMESPACE DESCRIPTION)" ]]; then
+            echo "::error::Documentation is out of date. Run devtools::document() locally and commit the changes."
+            echo ""
+            echo "Files that would change:"
+            git status --short -- man/ NAMESPACE DESCRIPTION
+            echo ""
+            echo "Diff:"
+            git --no-pager diff -- man/ NAMESPACE DESCRIPTION
+            exit 1
+          fi
+          echo "Documentation is up to date."

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -32,11 +32,16 @@ jobs:
 
       - name: Pin roxygen2 to the version recorded in DESCRIPTION
         run: |
-          ver <- read.dcf("DESCRIPTION")[, "Config/roxygen2/version"]
+          desc <- read.dcf("DESCRIPTION")
           current <- as.character(utils::packageVersion("roxygen2"))
-          if (!is.na(ver) && length(ver) == 1 && nzchar(ver) && current != ver) {
-            cat("Installing roxygen2 ", ver, " (currently ", current, ")\n", sep = "")
-            remotes::install_version("roxygen2", version = ver, repos = "https://cloud.r-project.org")
+          if ("Config/roxygen2/version" %in% colnames(desc)) {
+            ver <- desc[, "Config/roxygen2/version"]
+            if (!is.na(ver) && length(ver) == 1 && nzchar(ver) && current != ver) {
+              cat("Installing roxygen2 ", ver, " (currently ", current, ")\n", sep = "")
+              remotes::install_version("roxygen2", version = ver, repos = "https://cloud.r-project.org")
+            }
+          } else {
+            cat("No Config/roxygen2/version field found in DESCRIPTION; skipping roxygen2 pinning.\n")
           }
         shell: Rscript {0}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to ofemeantest
+
+Thanks for your interest in improving the package. This document covers
+the local dev setup we expect contributors to have before opening a PR.
+
+## Development setup
+
+1. Clone and open the project in your R IDE:
+
+   ```bash
+   git clone https://github.com/PPaccioretti/ofemeantest.git
+   cd ofemeantest
+   ```
+
+2. Install the dev dependencies (one-off):
+
+   ```r
+   install.packages(c("devtools", "roxygen2", "testthat", "pkgdown"))
+   ```
+
+3. **Enable the project's git hooks** (one-off per clone). This points
+   git at the versioned `.githooks/` directory so the pre-push check
+   runs on every `git push`:
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+   You can verify it took effect with `git config --get core.hooksPath`
+   (should print `.githooks`).
+
+## What the pre-push hook does
+
+Before every `git push` the hook runs `devtools::document()` and checks
+whether anything in `man/`, `NAMESPACE` or `DESCRIPTION` changed. If it
+did, the push is **blocked** with a list of files to commit. This
+prevents the most common source of "stale docs" PRs — editing a
+roxygen comment in `R/foo.R` and forgetting to regenerate the `.Rd`.
+
+To bypass the hook for a single push (e.g., emergency hotfix where
+the doc regen is unrelated):
+
+```bash
+git push --no-verify
+```
+
+The same check runs in GitHub Actions on every PR
+(`.github/workflows/document.yaml`), so even pushes that bypass the
+local hook will be caught at review time.
+
+## Running tests locally
+
+```r
+devtools::test()       # run testthat suite
+devtools::check()      # full R CMD check
+pkgdown::build_site()  # rebuild the docs site under docs/
+```
+
+The `docs/` directory is gitignored — it's only used for local preview
+and is rebuilt by CI on push to `main`.
+
+## Style
+
+- Keep functions documented with roxygen2; mark internals with
+  `@keywords internal`.
+- Add tests for new public behaviour. Contract tests in
+  `tests/testthat/test-dependency-contracts.R` guard the interfaces we
+  rely on from `spdep`, `spatialreg`, `permuco` and `multcompView` —
+  add a new entry there when you start depending on a new upstream
+  function.
+- Prefer base R over `dplyr`/`tidyr` to keep the Imports list small.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Description: Permutation-based statistical method to support field-specific
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.3
 Imports:
     multcompView,
     permuco,
@@ -35,3 +34,5 @@ VignetteBuilder: knitr
 Config/testthat/edition: 3
 URL: https://ppaccioretti.github.io/ofemeantest/, https://github.com/PPaccioretti/ofemeantest
 BugReports: https://github.com/PPaccioretti/ofemeantest/issues
+Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -56,3 +56,4 @@ reference:
   - title: Bundled data
     contents:
       - ofe_f2
+      - ofe_p

--- a/man/ofemeantest-package.Rd
+++ b/man/ofemeantest-package.Rd
@@ -22,6 +22,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Mariano Córdoba \email{marianoacba@agro.unc.edu.ar}
   \item Pablo Paccioretti \email{pablopaccioretti@agro.unc.edu.ar}
   \item Monica Balzarini \email{mbalzari@agro.unc.edu.ar}
 }


### PR DESCRIPTION
Adds two layers that catch stale roxygen-generated `man/` / `NAMESPACE` files before they reach review.

## What this PR adds

### 1. Local pre-push hook (`.githooks/pre-push`)

Runs `devtools::document()` before every `git push`, then aborts the push if it produced a diff under `man/`, `NAMESPACE` or `DESCRIPTION`. Off by default — contributors opt in once per clone:

```bash
git config core.hooksPath .githooks
```

The hook gracefully skips when `Rscript` or `devtools` is not on the contributor's machine, so non-R contributors (e.g., docs-only edits) are not blocked. To bypass for a single emergency hotfix push: `git push --no-verify`.

Includes a small portability fix: on Windows, Git Bash sets `LC_ALL=C.UTF-8` which native R does not recognise and falls back to "C" locale, mangling non-ASCII author names (`Córdoba` → `CC3rdoba`). The hook unsets locale vars before invoking Rscript so it inherits the OS-native UTF-8 locale.

### 2. CI doc-staleness check (`.github/workflows/document.yaml`)

Runs the same logic on every PR and on push to `main`. Pins `roxygen2` to the version recorded in `DESCRIPTION`'s `Config/roxygen2/version` so the regen output matches the maintainer's environment exactly — no false positives from a CI runner picking a newer roxygen.

This is the real enforcement layer. The local hook is the convenience layer that catches the issue before it reaches CI.

### 3. Supporting changes

- `CONTRIBUTING.md` — explains the one-time hook setup, the bypass flag, and the local dev workflow (`devtools::test()`, `devtools::check()`, `pkgdown::build_site()`).
- `.gitattributes` — pins `.githooks/*` and `*.sh` to LF endings so the shell scripts run on contributors with `autocrlf=true` (Windows default). Without this, bash refuses to interpret scripts with CRLF.
- `.Rbuildignore` — skips `.githooks/`, `.gitattributes`, and `CONTRIBUTING.md` so they do not end up in the built package.
- `DESCRIPTION` — reordered by roxygen 8.x (`Config/roxygen2/version: 8.0.0` and `RoxygenNote: 7.3.3` move to the end). No semantic change.

## Test plan

- [x] Local hook correctly blocks a push when `document()` produces a diff (verified by deliberately leaving a stale Rd).
- [x] Local hook lets the push through when docs are in sync (verified on this branch's push).
- [x] `devtools::check()` clean: 0 errors, 0 warnings, 0 notes.
- [ ] CI `document.yaml` workflow runs green on this PR.
- [ ] CI `R-CMD-check.yaml` matrix runs green on this PR (Ubuntu/macOS/Windows × release+devel+oldrel-1).
